### PR TITLE
Fix migration test failure, and update docs accordingly.

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -98,6 +98,11 @@ script is for an extension) or `haas` (if the script is for HaaS core).
 
 Alembic will generate a migration script in the appropriate directory. Again,
 sanity check the output; Alembic's guesses should not be trusted blindly.
+You should change value of the `branch_labels` variable to
+`(${branch_name},)` (do not leave out the trailing comma; this makes it
+a tuple rather than a single value). You should *not* modify the value
+of `down_revision`, which should only be changed when creating the first
+script for an extension.
 
 ## Writing tests
 

--- a/haas/migrations/versions/6a8c19565060_move_to_flask.py
+++ b/haas/migrations/versions/6a8c19565060_move_to_flask.py
@@ -13,7 +13,7 @@ Create Date: 2016-03-15 23:40:11.411599
 # revision identifiers, used by Alembic.
 revision = '6a8c19565060'
 down_revision = None
-branch_labels = ('haas',)
+branch_labels = None
 
 from alembic import op
 

--- a/haas/migrations/versions/89630e3872ec_networkacl2.py
+++ b/haas/migrations/versions/89630e3872ec_networkacl2.py
@@ -9,7 +9,7 @@ Create Date: 2016-05-06 09:24:26.911562
 # revision identifiers, used by Alembic.
 revision = '89630e3872ec'
 down_revision = '6a8c19565060'
-branch_labels = None
+branch_labels = ('haas',)
 
 from alembic import op
 import sqlalchemy as sa


### PR DESCRIPTION
Turns out my instructions were wrong. This fixes the bug and updates the docs. Before we merge #554, you probably ought to rename your migration script to remove the `2` bit; don't want that kind of debugging stuff in the final source tree.
